### PR TITLE
Add missing Python dependencies for the glusterfs-common package:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -78,7 +78,9 @@ Pre-Depends: ${misc:Pre-Depends},
 Depends: ${misc:Depends},
  ${shlibs:Depends},
  attr,
- psmisc
+ psmisc,
+ python-prettytable,
+ python-requests
 Conflicts: libglusterfs0,
  libglusterfs-dev
 Breaks: glusterfs-server (<< 3.4.0~qa5)


### PR DESCRIPTION
- Add python-requests as runtime dependency in order to be able to run
  /usr/sbin/gluster-eventsapi script.
- Add python-prettytable as runtime dependency in order to be able to
  run /usr/sbin/gluster-mountbroker.

Additional notes:

- I've tried double-checking all three packages to see if I can identify any other imports that might miss library. The main catch is that with python-requests a whole lot of additional packages get pulled-in as well.